### PR TITLE
RBS-JW-019, Bean Processing, add new processor with tests.  Can create beans.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,16 +22,15 @@ Goals for 0.3:
 
 Goals for 0.4:
   1. Handle parametrized types
-  2. Save compilation errors to CSV file
-  3. Support adding custom methods
-  4. Support bean creation: getters and setters
+  2. Support adding custom methods
+  3. Support bean creation: getters and setters
 
 Goals for 0.5
   1. Refinements needed for robust class building, to include:
      1. enum creation
      2. inner/anonymous class creation
      3. pre-method and inline comments
-  2. Optional: publish the object-oriented version of javawriter
+  2. Save compilation errors to CSV file
 
 Goals for 0.6 and above might not be disclosed.
 

--- a/src/main/java/com/rmbcorp/javawriter/BuildJob.java
+++ b/src/main/java/com/rmbcorp/javawriter/BuildJob.java
@@ -26,4 +26,8 @@ public interface BuildJob {
     String getBinPath();
 
     void setBinPath(String binPath);
+
+    static BuildJob get(String fileName, String relativePath) {
+        return new JavacJob(fileName, relativePath);
+    }
 }

--- a/src/main/java/com/rmbcorp/javawriter/JavaWriter.java
+++ b/src/main/java/com/rmbcorp/javawriter/JavaWriter.java
@@ -1,6 +1,7 @@
 package com.rmbcorp.javawriter;
 
 import com.rmbcorp.javawriter.processor.ClazzProcessor;
+import com.rmbcorp.javawriter.processor.ProcUtil;
 import com.rmbcorp.javawriter.processor.ProcessorProvider;
 import com.rmbcorp.util.argparser.ArgParser;
 import com.rmbcorp.util.argparser.ParserProv;
@@ -32,7 +33,7 @@ class JavaWriter {
 
     enum JavacOpts { CLASSPATH, D }
     enum JWOpts implements ArgParser.HasDefault {
-        DEBUGENV, USESOUT("false"), FILENAME, PACKAGE, GEN(Compiler.GEN_FOLDER), CLASSTYPE("class"), VISIBILITY(Visibility.PACKAGE.toString());
+        DEBUGENV, USESOUT("false"), FILENAME, PACKAGE, GEN(ProcUtil.GEN_FOLDER), CLASSTYPE("class"), VISIBILITY(Visibility.PACKAGE.toString());
 
         private final String defaultVal;
 
@@ -66,7 +67,7 @@ class JavaWriter {
         logger = new LoggerManager(useSout);
         compiler = new JavaCompiler(logger);
         clazzManager = ClazzImplManager.getInstance();
-        clazzProcessor = ProcessorProvider.get(ProcessorProvider.CLAZZIMPL);
+        clazzProcessor = ProcessorProvider.getClazzProcessor();
 
         JavacJob buildJob = getJavacJob(jwOptions, javacOptsMap);
         try {

--- a/src/main/java/com/rmbcorp/javawriter/autojavac/Compiler.java
+++ b/src/main/java/com/rmbcorp/javawriter/autojavac/Compiler.java
@@ -19,9 +19,6 @@ import com.rmbcorp.javawriter.BuildJob;
 
 public interface Compiler {
 
-    String GEN_FOLDER = "src/gen/";
-    String BIN_FOLDER = "bin/";
-
     void compile(BuildJob buildJob) throws AutoJavacException;
 
     void setParams(JavacParams... params);

--- a/src/main/java/com/rmbcorp/javawriter/clazz/Clazz.java
+++ b/src/main/java/com/rmbcorp/javawriter/clazz/Clazz.java
@@ -34,4 +34,5 @@ public interface Clazz {
     void addExtension(Class extension);
     void addImplementations(List<Class> implementation);
     void addMethod(JMethod jMethod);
+    void addBeanVariable(JVariable variable);
 }

--- a/src/main/java/com/rmbcorp/javawriter/clazz/ClazzImpl.java
+++ b/src/main/java/com/rmbcorp/javawriter/clazz/ClazzImpl.java
@@ -19,6 +19,7 @@ class ClazzImpl implements Clazz, ClazzReadable {
     private Class extension;
     private final Set<Class> implementations = new HashSet<>();
     private final Set<JMethod> methods = new HashSet<>();
+    private final Set<JVariable> variables = new HashSet<>();
 
 
     ClazzImpl(String packagePath, String className) {
@@ -71,7 +72,10 @@ class ClazzImpl implements Clazz, ClazzReadable {
         methods.add(jMethod);
     }
 
-
+    @Override
+    public void addBeanVariable(JVariable variable) {
+        variables.add(variable);
+    }
 
     @Override
     public String getPackagePath() {
@@ -121,5 +125,10 @@ class ClazzImpl implements Clazz, ClazzReadable {
     @Override
     public Set<JMethod> getMethods() {
         return methods;
+    }
+
+    @Override
+    public Set<JVariable> getBeanVariables() {
+        return variables;
     }
 }

--- a/src/main/java/com/rmbcorp/javawriter/clazz/ClazzReadable.java
+++ b/src/main/java/com/rmbcorp/javawriter/clazz/ClazzReadable.java
@@ -38,4 +38,6 @@ public interface ClazzReadable {
     Set<Class> getImplementations();
 
     Set<JMethod> getMethods();
+
+    Set<JVariable> getBeanVariables();
 }

--- a/src/main/java/com/rmbcorp/javawriter/clazz/JMethod.java
+++ b/src/main/java/com/rmbcorp/javawriter/clazz/JMethod.java
@@ -30,10 +30,11 @@ public class JMethod {
 
     public JMethod(Method method) {
         this.method = method;
+        this.name = method.getName();
     }
 
     public JMethod(String name, Class<?> returnType, Clazz.Visibility visibility, String packageName, Class<?>... params) {
-        this(null);
+        this.method = null;
         this.name = name;
         this.returnType = returnType;
         this.modifier = visibility.getModifier();

--- a/src/main/java/com/rmbcorp/javawriter/clazz/JVariable.java
+++ b/src/main/java/com/rmbcorp/javawriter/clazz/JVariable.java
@@ -16,6 +16,7 @@ public class JVariable {
     }
 
     public JVariable(String varName, Class<?> classType) {
+        visibility = Clazz.Visibility.PRIVATE;
         this.varName = varName;
         this.classType = classType;
         classTypeSimple = getClassSimpleName(classType.getSimpleName());

--- a/src/main/java/com/rmbcorp/javawriter/processor/BeanProcessor.java
+++ b/src/main/java/com/rmbcorp/javawriter/processor/BeanProcessor.java
@@ -1,0 +1,177 @@
+/*
+* Copyright 2017 by Robert M. Brako,
+* All rights reserved.
+*
+* Permission is not granted to any person or entity to obtain a copy of this software and associated files
+* (the "Software"), to deal in the Software, which includes without limitation any rights to use, copy, modify, merge,
+* publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+* furnished to do so.  Permission may only be obtained by a signed and dated license agreement between licensor Robert
+* Brako and prospective licensee.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+* WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+* COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+* OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+package com.rmbcorp.javawriter.processor;
+
+import com.rmbcorp.javawriter.clazz.Clazz;
+import com.rmbcorp.javawriter.clazz.ClazzImplManager;
+import com.rmbcorp.javawriter.clazz.ClazzReadable;
+import com.rmbcorp.javawriter.clazz.JMethod;
+import com.rmbcorp.javawriter.clazz.JVariable;
+import com.rmbcorp.util.ValidationManager;
+
+import java.util.*;
+
+
+final class BeanProcessor implements ClazzProcessor {
+
+    private final ValidationManager<ClazzImplManager.ClazzError> validator;
+    private final ClassStarter classStarter;
+    private final ProcUtil procUtil;
+    private StringBuilder builder;
+    private Map<String, String> varNames = new HashMap<>();
+    private String errorCache;
+
+    BeanProcessor(ValidationManager<ClazzImplManager.ClazzError> validator, ClassStarter classStarter, ProcUtil procUtil) {
+        this.validator = validator;
+        this.classStarter = classStarter;
+        this.procUtil = procUtil;
+    }
+
+    @Override
+    public boolean hasError(ClazzImplManager.ClazzError error) {
+        return errorCache.contains(error.toString());
+    }
+
+    @Override
+    public String writeOut(Clazz clazz) {
+        if (clazz instanceof ClazzReadable) {
+            String out = writeOut((ClazzReadable) clazz);
+            if (validator.hasErrors()) {
+                errorCache = ((ClazzValidator)validator).getErrorsAsCSV();
+                validator.removeAllResults();
+            }
+            return out;
+        }
+        else return "";
+    }
+
+    String writeOut(ClazzReadable clazz) {
+        reset();
+        int tabLevel = 0;
+        String packagePath = clazz.getPackagePath();
+        Set<Class> imports = new HashSet<>(clazz.getImports());
+        imports.addAll(clazz.getImplementations());
+        classStarter.buildHeader(packagePath, builder);
+        classStarter.buildClassOrInterface(builder, clazz.getClassType(), clazz);
+
+        Set<JMethod> beanMethods = getFromBeanVariables(packagePath, clazz.getBeanVariables());
+        beanMethods.addAll(clazz.getMethods());
+        beanMethods.stream().forEach(jMethod -> imports.add(jMethod.getReturnType()));
+
+        openBody();
+        buildBody(beanMethods, tabLevel + 1);
+        buildVariables(tabLevel + 1);
+        buildImports(imports);
+        closeBody();
+        return builder.toString();
+    }
+
+    private void reset() {
+        builder = new StringBuilder("");
+        errorCache = "";
+        varNames.clear();
+    }
+
+    private void openBody() {
+        builder.append(" {").append(procUtil.TWO_LINES);
+        builder.append(procUtil.VARIABLE_PLACEHOLDER).append(procUtil.ONE_LINE);
+    }
+
+    private Set<JMethod> getFromBeanVariables(String packagePath, Set<JVariable> beanVariables) {
+        Set<JMethod> methods = new HashSet<>();
+        for (JVariable variable : beanVariables) {
+            methods.add(new JMethod("set" + firstUpper(variable.getName()), Void.class, Clazz.Visibility.PUBLIC, packagePath, variable.getClassType()));
+            if ("boolean".equalsIgnoreCase(variable.getType())) {
+                methods.add(new JMethod("is" + firstUpper(variable.getName()), variable.getClassType(), Clazz.Visibility.PUBLIC, packagePath));
+            } else {
+                methods.add(new JMethod("get" + firstUpper(variable.getName()), variable.getClassType(), Clazz.Visibility.PUBLIC, packagePath));
+            }
+        }
+        return methods;
+    }
+
+    private String firstUpper(String name) {
+        char[] paramCopy = JavaKeywords.replaceJavaKeyword(name).toCharArray();
+        paramCopy[0] = Character.toUpperCase(paramCopy[0]);
+        return new String(paramCopy);
+    }
+
+    private void buildBody(Set<JMethod> methods, int lev) {
+        List<String> varCache = new ArrayList<>(2);
+        for (JMethod method : methods) {
+            varCache.clear();
+            ProcUtil.ReturnParams returnParams = procUtil.getReturnAndParams(method);
+            String returnType = procUtil.dollarToDot(returnParams.getReturnType());
+            List<String> preParams = returnParams.getParams();
+
+            builder.append(procUtil.tab(lev))
+                    .append(procUtil.getScope(method.getModifier()))
+                    .append(returnType).append(' ')
+                    .append(method.getName()).append('(');
+            for (Iterator<String> iterator = preParams.iterator(); iterator.hasNext(); ) {
+                String variable = iterator.next();
+                String varType = procUtil.toPrimitive(procUtil.getClassSimpleName(variable));
+                String varName = procUtil.getVarName(method.getName().replaceFirst("set", ""));
+                varNames.put(varName, varType);
+                varCache.add(varName);
+                builder.append(varType).append(' ').append(varName);
+                if (iterator.hasNext()) {
+                    builder.append(", ");
+                }
+            }
+            builder.append(") {\n");
+            buildMethod(varCache, method.getName(), lev + 1);
+            builder.append(procUtil.tab(lev)).append("}\n");
+        }
+    }
+
+    private void buildMethod(List<String> varCache, String methodName, int lev) {
+        if (methodName.startsWith("get") || methodName.startsWith("is")) {
+            builder.append(procUtil.tab(lev))
+                    .append("return ")
+                    .append(procUtil.getVarName(methodName.replaceFirst("get", "")))
+                    .append(";\n");
+        } else {
+            for (String var : varCache) {
+                builder.append(procUtil.tab(lev)).append("this.").append(var).append(" = ").append(var).append(";\n");
+            }
+        }
+    }
+
+    private void buildVariables(int lev) {
+        StringBuilder varBuilder = new StringBuilder();
+        varNames.forEach((varName, varType) -> varBuilder.append(procUtil.tab(lev)).append("private ").append(varType).append(' ').append(varName).append(";\n"));
+        int varIndex = builder.indexOf(procUtil.VARIABLE_PLACEHOLDER);
+        builder.replace(varIndex, varIndex + procUtil.VARIABLE_PLACEHOLDER.length(), varBuilder.toString());
+    }
+
+    private void buildImports(Set<Class> imports) {
+        StringBuilder importBuilder = new StringBuilder();
+        for (Class aClass : imports) {
+            String importName = aClass.getCanonicalName();
+            if (!importName.startsWith("java.lang")) {
+                importBuilder.append("import ").append(procUtil.dollarToDot(importName)).append(';').append(procUtil.ONE_LINE);
+            }
+        }
+        int start = builder.indexOf(procUtil.IMPORT_PLACEHOLDER);
+        int end = start + procUtil.IMPORT_PLACEHOLDER.length();
+        builder.replace(start, end, importBuilder.toString());
+    }
+
+    private void closeBody() {
+        builder.append("}\n");
+    }
+}

--- a/src/main/java/com/rmbcorp/javawriter/processor/ClassStarter.java
+++ b/src/main/java/com/rmbcorp/javawriter/processor/ClassStarter.java
@@ -15,11 +15,11 @@
 */
 package com.rmbcorp.javawriter.processor;
 
-import com.rmbcorp.javawriter.clazz.Clazz;
-import com.rmbcorp.javawriter.clazz.ClazzImplManager;
-import com.rmbcorp.javawriter.clazz.ClazzReadable;
+import com.rmbcorp.javawriter.clazz.*;
 import com.rmbcorp.util.StringUtil;
 
+import java.lang.reflect.Method;
+import java.util.HashSet;
 import java.util.Set;
 
 public class ClassStarter {
@@ -72,21 +72,33 @@ public class ClassStarter {
         builder.append("interface ").append(className);
     }
 
-    void buildImplementations(StringBuilder builder, Clazz.ClassType classType, Set<Class> implementations) {
+    Set<JMethod> buildImplementations(StringBuilder builder, Clazz.ClassType classType, Set<Class> implementations) {
+        Set<JMethod> methods = new HashSet<>();
         if (!implementations.isEmpty()) {
             builder.append(Clazz.ClassType.CLASS.equals(classType) ? " implements " : " extends ");
             for (Class object : implementations) {
                 builder.append(procUtil.dollarToDot(procUtil.getClassSimpleName(object.toString())));
                 builder.append(", ");
+                for (Method method : object.getDeclaredMethods()) {
+                    methods.add(new JMethod(method));
+                }
             }
             trimComma(builder);
         }
+        return methods;
     }
 
-    private void trimComma(StringBuilder result) {
-        int length = result.lastIndexOf(", ");
+    private void trimComma(StringBuilder builder) {
+        int length = builder.lastIndexOf(", ");
         if (length != -1) {
-            result.replace(length, length + 1, "");
+            builder.replace(length, length + 1, "");
         }
+    }
+
+    void buildHeader(String packagePath, StringBuilder builder) {
+        if (!StringUtil.isEmpty(packagePath)) {
+            builder.append("package ").append(packagePath).append(';').append(procUtil.ONE_LINE).append(procUtil.ONE_LINE);
+        }
+        builder.append(procUtil.IMPORT_PLACEHOLDER).append(procUtil.ONE_LINE);
     }
 }

--- a/src/main/java/com/rmbcorp/javawriter/processor/ClazzImplProcessor.java
+++ b/src/main/java/com/rmbcorp/javawriter/processor/ClazzImplProcessor.java
@@ -1,10 +1,7 @@
 package com.rmbcorp.javawriter.processor;
 
-import com.rmbcorp.javawriter.clazz.Clazz;
+import com.rmbcorp.javawriter.clazz.*;
 import com.rmbcorp.javawriter.clazz.ClazzImplManager.ClazzError;
-import com.rmbcorp.javawriter.clazz.ClazzReadable;
-import com.rmbcorp.javawriter.clazz.JMethod;
-import com.rmbcorp.javawriter.clazz.JVariable;
 import com.rmbcorp.util.StringUtil;
 import com.rmbcorp.util.ValidationManager;
 
@@ -209,25 +206,29 @@ final class ClazzImplProcessor implements ClazzProcessor {
                 builder.append(", ");
             }
             variables.put(new JVariable(varName, simpleName), makeSetter);
-            boolean found = false;
-            if (!param.equals(simpleName)) {
-                for (Class clazz : imports) {//future: make more efficient
-                    if (clazz.getSimpleName().contains(trimmedParam)) {
-                        found = true;
-                    }
-                }
-                if (!found) {
-                    try {
-                        imports.add(Class.forName(cleanParamString(param)));
-                    } catch (ClassNotFoundException ignored) {
-                        Logger.getGlobal().log(Level.INFO, ignored.getLocalizedMessage(), ignored);
-                        validator.addResult(ClazzError.INVALID_CLASS_NAME);
-                    }
-                }
-            }
+            resolveParamImports(imports, param, simpleName, trimmedParam);
         }
         builder.append(")");
         return variables;
+    }
+
+    private void resolveParamImports(Set<Class> imports, String param, String simpleName, String trimmedParam) {
+        boolean found = false;
+        if (!param.equals(simpleName)) {
+            for (Class clazz : imports) {//future: make more efficient
+                if (clazz.getSimpleName().contains(trimmedParam)) {
+                    found = true;
+                }
+            }
+            if (!found) {
+                try {
+                    imports.add(Class.forName(cleanParamString(param)));
+                } catch (ClassNotFoundException ignored) {
+                    Logger.getGlobal().log(Level.INFO, ignored.getLocalizedMessage(), ignored);
+                    validator.addResult(ClazzError.INVALID_CLASS_NAME);
+                }
+            }
+        }
     }
 
     private String cleanParamString(String string) {

--- a/src/main/java/com/rmbcorp/javawriter/processor/ProcUtil.java
+++ b/src/main/java/com/rmbcorp/javawriter/processor/ProcUtil.java
@@ -22,6 +22,9 @@ import java.util.*;
 
 public class ProcUtil {
 
+    public static final String GEN_FOLDER = "src/gen/";
+    public static final String BIN_FOLDER = "bin/";
+
     final String IMPORT_PLACEHOLDER = "//%%IMPORTS%%";
     final String VARIABLE_PLACEHOLDER = "//%%VARIABLES%%";
     final char ONE_LINE = '\n';

--- a/src/main/java/com/rmbcorp/javawriter/processor/ProcessorProvider.java
+++ b/src/main/java/com/rmbcorp/javawriter/processor/ProcessorProvider.java
@@ -15,29 +15,21 @@
 */
 package com.rmbcorp.javawriter.processor;
 
-import java.util.EnumMap;
-import java.util.Map;
+public class ProcessorProvider {
 
-public enum ProcessorProvider {
+    private ProcessorProvider() { }
 
-    CLAZZIMPL;
+    public static ClazzProcessor getBeanProcessor() {
+        ClazzValidator validator = new ClazzValidator();
+        ProcUtil procUtil = new ProcUtil();
+        ClassStarter classStarter = new ClassStarter(validator, procUtil);
+        return new BeanProcessor(validator, classStarter, procUtil);
+    }
 
-    private static Map<ProcessorProvider, ClazzProcessor> processorMap = new EnumMap<>(ProcessorProvider.class);
-
-
-    public static ClazzProcessor get(ProcessorProvider type) {
-        if (processorMap.get(type) == null) {
-            ProcUtil procUtil = new ProcUtil();
-            switch (type) {
-                case CLAZZIMPL:
-                    ClazzValidator validator = new ClazzValidator();
-                    processorMap.put(CLAZZIMPL,
-                            new ClazzImplProcessor(validator, new ClassStarter(validator, procUtil), procUtil));
-                    break;
-                default:
-                    break;
-            }
-        }
-        return processorMap.get(type);
+    public static ClazzProcessor getClazzProcessor() {
+        ClazzValidator validator = new ClazzValidator();
+        ProcUtil procUtil = new ProcUtil();
+        ClassStarter classStarter = new ClassStarter(validator, procUtil);
+        return new ClazzImplProcessor(validator, classStarter, procUtil);
     }
 }

--- a/src/test/java/com/rmbcorp/javawriter/clazz/ClazzImplTest.java
+++ b/src/test/java/com/rmbcorp/javawriter/clazz/ClazzImplTest.java
@@ -35,7 +35,7 @@ public class ClazzImplTest {
     @Before
     public void setUp() throws Exception {
         clazzManager = ClazzImplManager.getInstance();
-        clazzProcessor = ProcessorProvider.get(ProcessorProvider.CLAZZIMPL);
+        clazzProcessor = ProcessorProvider.getClazzProcessor();
         clazz = clazzManager.get(COM_RMBCORP_JAVAWRITER, "ClazzImpl2");
         setupClass(Collections.<Class>singletonList(Clazz.class));
     }


### PR DESCRIPTION
Considering version upgrade to 0.3-SNAPHOT to allow early testing within local network.  Cannot bump version to 0.4 until Saving Errors as CSV is implemented and tested.  But overall objective is to not use SNAPSHOT versions.  So, options seem to be:
1. Proceed with bump to 0.3-SNAPSHOT
2. No version change - hurry up with 0.4 release
3. Change roadmap and push the CSV feature to after version 0.4
4. Create ad-hoc version 0.3.1

Will probably pick option 1 or 2 after some thought.